### PR TITLE
fix(s3upload): 修复上传到云服务出现重复桶名目录问题

### DIFF
--- a/yudao-module-infra/yudao-module-infra-biz/src/main/java/cn/iocoder/yudao/module/infra/framework/file/core/client/s3/S3FileClient.java
+++ b/yudao-module-infra/yudao-module-infra-biz/src/main/java/cn/iocoder/yudao/module/infra/framework/file/core/client/s3/S3FileClient.java
@@ -37,6 +37,7 @@ public class S3FileClient extends AbstractFileClient<S3FileClientConfig> {
                 .region(buildRegion()) // Region
                 .credentials(config.getAccessKey(), config.getAccessSecret()) // 认证密钥
                 .build();
+        client.enableVirtualStyleEndpoint();
     }
 
     /**


### PR DESCRIPTION
上传到腾讯云COS出现了多余的桶名目录前缀导致无法直接通过拼接访问域名加路径访问。
排查后发现此处会直接把桶名进行前缀拼接。目前已经修正测试恢复正常。