### PR TITLE
feat(excel): 添加自适应列宽处理器并替换默认列宽策略

### DIFF
--- a/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/core/job/TenantJobAspect.java
+++ b/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/core/job/TenantJobAspect.java
@@ -50,12 +50,6 @@ public class TenantJobAspect {
             TenantUtils.execute(tenantId, () -> {
                 try {
                     Object result = joinPoint.proceed();
-                    if(null == result){
-                        XxlJobHelper.log(StrUtil.format("[多租户({}) 执行任务({})，结果为：null]",
-                                tenantId, joinPoint.getSignature()));
-                        //避免ConcurrentHashMap put空指针异常
-                        result = "";
-                    }
                     results.put(tenantId, StrUtil.toStringOrEmpty(result));
                 } catch (Throwable e) {
                     results.put(tenantId, ExceptionUtil.getRootCauseMessage(e));

--- a/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/core/job/TenantJobAspect.java
+++ b/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/core/job/TenantJobAspect.java
@@ -50,6 +50,12 @@ public class TenantJobAspect {
             TenantUtils.execute(tenantId, () -> {
                 try {
                     Object result = joinPoint.proceed();
+                    if(null == result){
+                        XxlJobHelper.log(StrUtil.format("[多租户({}) 执行任务({})，结果为：null]",
+                                tenantId, joinPoint.getSignature()));
+                        //避免ConcurrentHashMap put空指针异常
+                        result = "";
+                    }
                     results.put(tenantId, StrUtil.toStringOrEmpty(result));
                 } catch (Throwable e) {
                     results.put(tenantId, ExceptionUtil.getRootCauseMessage(e));

--- a/yudao-framework/yudao-spring-boot-starter-excel/src/main/java/cn/iocoder/yudao/framework/excel/core/handler/ColumnWidthMatchStyleStrategy.java
+++ b/yudao-framework/yudao-spring-boot-starter-excel/src/main/java/cn/iocoder/yudao/framework/excel/core/handler/ColumnWidthMatchStyleStrategy.java
@@ -1,0 +1,73 @@
+package cn.iocoder.yudao.framework.excel.core.handler;
+
+import com.alibaba.excel.enums.CellDataTypeEnum;
+import com.alibaba.excel.metadata.Head;
+import com.alibaba.excel.metadata.data.WriteCellData;
+import com.alibaba.excel.util.MapUtils;
+import com.alibaba.excel.write.metadata.holder.WriteSheetHolder;
+import com.alibaba.excel.write.style.column.AbstractColumnWidthStyleStrategy;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.poi.ss.usermodel.Cell;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+/**
+ * 自适应列宽处理器
+ *
+ * @author hmb
+ */
+public class ColumnWidthMatchStyleStrategy extends AbstractColumnWidthStyleStrategy {
+    private static final int MAX_COLUMN_WIDTH = 255;
+    private final Map<Integer, Map<Integer, Integer>> cache = MapUtils.newHashMapWithExpectedSize(8);
+
+    public ColumnWidthMatchStyleStrategy() {
+    }
+
+    @Override
+    protected void setColumnWidth(WriteSheetHolder writeSheetHolder, List<WriteCellData<?>> cellDataList, Cell cell,
+                                  Head head,
+                                  Integer relativeRowIndex, Boolean isHead) {
+        boolean needSetWidth = isHead || !CollectionUtils.isEmpty(cellDataList);
+        if (!needSetWidth) {
+            return;
+        }
+        Map<Integer, Integer> maxColumnWidthMap = cache.computeIfAbsent(writeSheetHolder.getSheetNo(), key -> new HashMap<>(16));
+        Integer columnWidth = dataLength(cellDataList, cell, isHead);
+        if (columnWidth < 0) {
+            return;
+        }
+        if (columnWidth > MAX_COLUMN_WIDTH) {
+            columnWidth = MAX_COLUMN_WIDTH;
+        }
+        Integer maxColumnWidth = maxColumnWidthMap.get(cell.getColumnIndex());
+        if (maxColumnWidth == null || columnWidth > maxColumnWidth) {
+            maxColumnWidthMap.put(cell.getColumnIndex(), columnWidth);
+            writeSheetHolder.getSheet().setColumnWidth(cell.getColumnIndex(), (columnWidth+3) * 256);
+        }
+    }
+
+    private Integer dataLength(List<WriteCellData<?>> cellDataList, Cell cell, Boolean isHead) {
+        if (isHead) {
+            return cell.getStringCellValue().getBytes().length;
+        }
+        WriteCellData<?> cellData = cellDataList.get(0);
+        CellDataTypeEnum type = cellData.getType();
+        if (type == null) {
+            return -1;
+        }
+        switch (type) {
+            case STRING:
+                return cellData.getStringValue().getBytes().length;
+            case BOOLEAN:
+                return cellData.getBooleanValue().toString().getBytes().length;
+            case NUMBER:
+                return cellData.getNumberValue().toString().getBytes().length;
+            case DATE:
+                return cellData.getDateValue().toString().getBytes().length;
+            default:
+                return -1;
+        }
+    }
+}
+

--- a/yudao-framework/yudao-spring-boot-starter-excel/src/main/java/cn/iocoder/yudao/framework/excel/core/util/ExcelUtils.java
+++ b/yudao-framework/yudao-spring-boot-starter-excel/src/main/java/cn/iocoder/yudao/framework/excel/core/util/ExcelUtils.java
@@ -1,5 +1,6 @@
 package cn.iocoder.yudao.framework.excel.core.util;
 
+import cn.iocoder.yudao.framework.excel.core.handler.ColumnWidthMatchStyleStrategy;
 import cn.iocoder.yudao.framework.excel.core.handler.SelectSheetWriteHandler;
 import com.alibaba.excel.EasyExcel;
 import com.alibaba.excel.converters.longconverter.LongStringConverter;
@@ -35,7 +36,7 @@ public class ExcelUtils {
         // 输出 Excel
         EasyExcel.write(response.getOutputStream(), head)
                 .autoCloseStream(false) // 不要自动关闭，交给 Servlet 自己处理
-                .registerWriteHandler(new LongestMatchColumnWidthStyleStrategy()) // 基于 column 长度，自动适配。最大 255 宽度
+                .registerWriteHandler(new ColumnWidthMatchStyleStrategy()) // 基于 column 长度，自动适配。最大 255 宽度
                 .registerWriteHandler(new SelectSheetWriteHandler(head)) // 基于固定 sheet 实现下拉框
                 .registerConverter(new LongStringConverter()) // 避免 Long 类型丢失精度
                 .sheet(sheetName).doWrite(data);


### PR DESCRIPTION
- 新增 ColumnWidthMatchStyleStrategy 类实现自适应列宽功能。增加了日期类型数据的自适应支持
- 在 ExcelUtils 类中使用新的列宽处理器替换原有的 LongestMatchColumnWidthStyleStrategy
- LongestMatchColumnWidthStyleStrategy默认的自适应宽度效果如下（列宽偏小+不支持日期类型）
​​​​
![Uploading 1733363085909.png…]()
