### PR TITLE
feat(framework): 通用的子表批量更新方法、修改非ERP模式时子表更新的代码模板

### DIFF
--- a/yudao-module-infra/yudao-module-infra-biz/src/main/resources/codegen/java/service/serviceImpl.vm
+++ b/yudao-module-infra/yudao-module-infra-biz/src/main/resources/codegen/java/service/serviceImpl.vm
@@ -1,5 +1,6 @@
 package ${basePackage}.module.${table.moduleName}.service.${table.businessName};
 
+import cn.hutool.core.collection.CollUtil;
 import org.springframework.stereotype.Service;
 import ${jakartaPackage}.annotation.Resource;
 import org.springframework.validation.annotation.Validated;
@@ -318,9 +319,16 @@ public class ${table.className}ServiceImpl implements ${table.className}Service 
     }
 
     private void update${subSimpleClassName}List(${primaryColumn.javaType} ${subJoinColumn.javaField}, List<${subTable.className}DO> list) {
-        delete${subSimpleClassName}By${SubJoinColumnName}(${subJoinColumn.javaField});
-		list.forEach(o -> o.setId(null).setUpdater(null).setUpdateTime(null)); // 解决更新情况下：1）id 冲突；2）updateTime 不更新
-        create${subSimpleClassName}List(${subJoinColumn.javaField}, list);
+        if (CollUtil.isEmpty(list)) return;
+##        delete${subSimpleClassName}By${SubJoinColumnName}(${subJoinColumn.javaField});
+##		list.forEach(o -> o.setId(null).setUpdater(null).setUpdateTime(null)); // 解决更新情况下：1）id 冲突；2）updateTime 不更新
+##        create${subSimpleClassName}List(${subJoinColumn.javaField}, list);
+        List<${subTable.className}DO> dbList = ${subClassNameVars.get($index)}Mapper.selectList(${subTable.className}DO::get${SubJoinColumnName}, ${subJoinColumn.javaField});
+
+        ${subClassNameVars.get($index)}Mapper.subListUpdateBatch(
+                ${subJoinColumn.javaField}, ${subTable.className}DO::setId,
+                list, dbList, ${subTable.className}DO::getId
+        );
     }
 
     #else


### PR DESCRIPTION
每次子表更新时都会全部删除再重建

逻辑上没问题，但子表使用逻辑删除时，数据库中会产生很多重复的脏数据

于是参考`cn.iocoder.yudao.module.system.service.permission.PermissionServiceImpl#assignRoleMenu`方法，封装了一个通用的子表批量更新方法

处理逻辑如下：
1. 带id的数据 => 需要修改
2. 没有id的数据 => 需要添加
3. 数据库里有这个id，但前端传过来的数据没有 => 需要删除

顺便把该方法加到代码模板里了