### PR TITLE
fix：在删除插件文件时，增加对文件名为空的检查，避免空文件名导致的错误

### DIFF
--- a/yudao-module-iot/yudao-module-iot-biz/src/main/java/cn/iocoder/yudao/module/iot/service/plugin/IotPluginInstanceServiceImpl.java
+++ b/yudao-module-iot/yudao-module-iot-biz/src/main/java/cn/iocoder/yudao/module/iot/service/plugin/IotPluginInstanceServiceImpl.java
@@ -2,6 +2,7 @@ package cn.iocoder.yudao.module.iot.service.plugin;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.io.FileUtil;
+import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.iocoder.yudao.framework.tenant.core.util.TenantUtils;
 import cn.iocoder.yudao.module.iot.api.device.dto.control.upstream.IotPluginInstanceHeartbeatReqDTO;
@@ -135,6 +136,10 @@ public class IotPluginInstanceServiceImpl implements IotPluginInstanceService {
 
     @Override
     public void deletePluginFile(IotPluginConfigDO pluginConfigDO) {
+        if (ObjectUtil.isEmpty(pluginConfigDO.getFileName())) {
+            log.warn("[deletePluginFile][插件配置({}) 的文件名为空，无法删除]", pluginConfigDO);
+            return;
+        }
         File file = new File(pluginsDir, pluginConfigDO.getFileName());
         if (!file.exists()) {
             return;


### PR DESCRIPTION
IoT 物联网 -> 运维管理 -> 插件管理 中没有上传插件包的插件在删除时会报错