### PR TITLE
fix: 修复Gateway网关使用Webflux,导致skywalking日志打印traceId失效.

### DIFF
--- a/yudao-dependencies/pom.xml
+++ b/yudao-dependencies/pom.xml
@@ -44,7 +44,7 @@
         <!-- 服务保障相关 -->
         <lock4j.version>2.2.7</lock4j.version>
         <!-- 监控相关 -->
-        <skywalking.version>9.5.0</skywalking.version>
+        <skywalking.version>9.4.0</skywalking.version>
         <spring-boot-admin.version>3.5.2</spring-boot-admin.version>
         <opentracing.version>0.33.0</opentracing.version>
         <!-- Test 测试相关 -->
@@ -380,7 +380,11 @@
                 <artifactId>yudao-spring-boot-starter-monitor</artifactId>
                 <version>${revision}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.skywalking</groupId>
+                <artifactId>apm-toolkit-webflux</artifactId>
+                <version>${skywalking.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.skywalking</groupId>
                 <artifactId>apm-toolkit-trace</artifactId>

--- a/yudao-dependencies/pom.xml
+++ b/yudao-dependencies/pom.xml
@@ -44,7 +44,7 @@
         <!-- 服务保障相关 -->
         <lock4j.version>2.2.7</lock4j.version>
         <!-- 监控相关 -->
-        <skywalking.version>9.4.0</skywalking.version>
+        <skywalking.version>9.5.0</skywalking.version>
         <spring-boot-admin.version>3.5.2</spring-boot-admin.version>
         <opentracing.version>0.33.0</opentracing.version>
         <!-- Test 测试相关 -->

--- a/yudao-framework/yudao-spring-boot-starter-monitor/pom.xml
+++ b/yudao-framework/yudao-spring-boot-starter-monitor/pom.xml
@@ -42,6 +42,11 @@
 
         <!-- 监控相关 -->
         <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>apm-toolkit-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
             <optional>true</optional>
@@ -49,12 +54,10 @@
         <dependency>
             <groupId>org.apache.skywalking</groupId>
             <artifactId>apm-toolkit-trace</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.skywalking</groupId>
             <artifactId>apm-toolkit-logback-1.x</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.skywalking</groupId>

--- a/yudao-framework/yudao-spring-boot-starter-monitor/src/main/java/cn/iocoder/yudao/framework/tracer/core/util/TracerFrameworkUtils.java
+++ b/yudao-framework/yudao-spring-boot-starter-monitor/src/main/java/cn/iocoder/yudao/framework/tracer/core/util/TracerFrameworkUtils.java
@@ -2,6 +2,9 @@ package cn.iocoder.yudao.framework.tracer.core.util;
 
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
+import org.apache.skywalking.apm.toolkit.webflux.WebFluxSkyWalkingTraceContext;
+import org.slf4j.MDC;
+import org.springframework.web.server.ServerWebExchange;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -14,6 +17,10 @@ import java.util.Map;
  * @author 芋道源码
  */
 public class TracerFrameworkUtils {
+    /**
+     * 链路追踪的 TraceId 不存在时，使用的默认值
+     */
+    private static final String TRACE_ID_DEFAULT = "N/A";
 
     /**
      * 将异常记录到 Span 中，参考自 com.aliyuncs.utils.TraceUtils
@@ -43,4 +50,74 @@ public class TracerFrameworkUtils {
         return errorLogs;
     }
 
+    /**
+     * 获取 TraceId
+     *
+     * @param exchange ServerWebExchange
+     * @return TraceId
+     *
+     */
+    public static String getTraceId(ServerWebExchange exchange) {
+        try {
+            String traceId = WebFluxSkyWalkingTraceContext.traceId(exchange);
+            return TRACE_ID_DEFAULT.equals(traceId) ? null : traceId;
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * 将 TraceId 放入 MDC，默认 key=tid
+     *
+     * @param exchange ServerWebExchange
+     *
+     */
+    public static void putTidIntoMdc(ServerWebExchange exchange) {
+        putTidIntoMdc(exchange, "tid");
+    }
+
+    /**
+     * 将 TraceId 放入 MDC，指定 key
+     *
+     * @param exchange ServerWebExchange
+     * @param key      MDC key
+     *
+     */
+    public static void putTidIntoMdc(ServerWebExchange exchange, String key) {
+        String traceId = getTraceId(exchange);
+        if (traceId != null) {
+            MDC.put(key, traceId);
+        }
+    }
+
+    /**
+     * 将 TraceId 放入 MDC，传入 traceId 和 key
+     *
+     * @param traceId TraceId
+     * @param key     MDC key
+     *
+     */
+    public static void putTidIntoMdc(String traceId, String key) {
+        if (traceId != null && !TRACE_ID_DEFAULT.equals(traceId)) {
+            MDC.put(key, traceId);
+        }
+    }
+
+    /**
+     * 从 MDC 中移除 TraceId，默认 key=tid
+     *
+     */
+    public static void removeTidFromMdc() {
+        removeTidFromMdc("tid");
+    }
+
+    /**
+     * 从 MDC 中移除 TraceId，指定 key
+     *
+     * @param key MDC key
+     *
+     */
+    public static void removeTidFromMdc(String key) {
+        MDC.remove(key);
+    }
 }

--- a/yudao-gateway/src/main/java/cn/iocoder/yudao/gateway/filter/logging/AccessLogFilter.java
+++ b/yudao-gateway/src/main/java/cn/iocoder/yudao/gateway/filter/logging/AccessLogFilter.java
@@ -4,6 +4,7 @@ import cn.hutool.core.date.LocalDateTimeUtil;
 import cn.hutool.core.map.MapUtil;
 import cn.hutool.json.JSONUtil;
 import cn.iocoder.yudao.framework.common.util.json.JsonUtils;
+import cn.iocoder.yudao.framework.tracer.core.util.TracerFrameworkUtils;
 import cn.iocoder.yudao.gateway.util.SecurityFrameworkUtils;
 import cn.iocoder.yudao.gateway.util.WebFrameworkUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -103,7 +104,8 @@ public class AccessLogFilter implements GlobalFilter, Ordered {
 
     @Override
     public int getOrder() {
-        return Ordered.HIGHEST_PRECEDENCE;
+        // +1 为了让获取TraceId的过滤器优先执行
+        return Ordered.HIGHEST_PRECEDENCE + 1;
     }
 
     @Override
@@ -112,6 +114,7 @@ public class AccessLogFilter implements GlobalFilter, Ordered {
         ServerHttpRequest request = exchange.getRequest();
         // TODO traceId
         AccessLog gatewayLog = new AccessLog();
+        gatewayLog.setTraceId(TracerFrameworkUtils.getTraceId(exchange));
         gatewayLog.setRoute(WebFrameworkUtils.getGatewayRoute(exchange));
         gatewayLog.setSchema(request.getURI().getScheme());
         gatewayLog.setRequestMethod(request.getMethod().name());

--- a/yudao-gateway/src/main/java/cn/iocoder/yudao/gateway/filter/logging/TraceIdMdcGlobalFilter.java
+++ b/yudao-gateway/src/main/java/cn/iocoder/yudao/gateway/filter/logging/TraceIdMdcGlobalFilter.java
@@ -1,0 +1,35 @@
+package cn.iocoder.yudao.gateway.filter.logging;
+
+import cn.iocoder.yudao.framework.tracer.core.util.TracerFrameworkUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * 从 Reactor Context 中获取 traceId，填充到 MDC 中
+ */
+@Component
+@Slf4j
+public class TraceIdMdcGlobalFilter implements GlobalFilter, Ordered {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        // 延迟从 Reactor Context 拿 traceId，保证 SkyWalking 已经初始化
+        return Mono.deferContextual(ctxView -> {
+            TracerFrameworkUtils.putTidIntoMdc(exchange);
+            // chain.filter 返回的是 Mono<Void>，doFinally 确保每次请求结束清理 MDC
+            return chain.filter(exchange)
+                    .doFinally(signalType -> TracerFrameworkUtils.removeTidFromMdc());
+        });
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}
+

--- a/yudao-gateway/src/main/java/cn/iocoder/yudao/gateway/handler/GlobalExceptionHandler.java
+++ b/yudao-gateway/src/main/java/cn/iocoder/yudao/gateway/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package cn.iocoder.yudao.gateway.handler;
 
 import cn.iocoder.yudao.framework.common.pojo.CommonResult;
+import cn.iocoder.yudao.framework.tracer.core.util.TracerFrameworkUtils;
 import cn.iocoder.yudao.gateway.util.WebFrameworkUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
@@ -29,6 +30,8 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
 
     @Override
     public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        // 如果请求到网关时，由于没有服务直接被拦截，不走过滤器（TraceIdMdcGlobalFilter），需要手动重新添加 TraceId
+        TracerFrameworkUtils.putTidIntoMdc(exchange);
         // 已经 commit，则直接返回异常
         ServerHttpResponse response = exchange.getResponse();
         if (response.isCommitted()) {

--- a/yudao-gateway/src/main/resources/logback-spring.xml
+++ b/yudao-gateway/src/main/resources/logback-spring.xml
@@ -35,11 +35,12 @@
     </appender>
 
     <!-- SkyWalking Appender：GRPC 日志收集，实现日志中心 -->
+    <!-- [TID:%X{tid}] 手动存储MDC使用，[[%tid]] 普通请求自动填充-->
     <!--
     <appender name="SKYWALKING" class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.log.GRPCLogClientAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.TraceIdPatternLogbackLayout">
-                <pattern>[%tid] ${FILE_LOG_PATTERN}</pattern>
+                <pattern>[TID:%X{tid}] ${FILE_LOG_PATTERN}</pattern>
             </layout>
         </encoder>
     </appender>


### PR DESCRIPTION
解决方案：
使用Webflux的插件以及包工具，手动获取TraceId后设置到MDC.（WebFluxSkyWalkingTraceContext.traceId(exchange)）

解决步骤：
1、首先下载Skywalking Agent后，查看Plugin文件夹下是否存在Weblux以及Gateway相关的jar包，如果不存在需要从option-plugin文件夹进行拷贝。
2、引入依赖 apm-toolkit-webflux，与Skywalking版本一致
3、编写工具类或者直接通过方法获取
4、编写过滤器：gateway.filter 下的GlobalFilter，设置优先顺序执行 （不能是WebFliter）。
5、Gateway异常处理需要重新获取

注意：本次修复测试skywalking的版本依赖于9.4.0，而项目中版本为9.5.0。每个版本的Agent可能存在不同，请使用时注意版本问题。