### PR TITLE
fix(codegen): sync uniapp golden files with updated velocity templates

### DIFF
--- a/yudao-module-infra/yudao-module-infra-server/src/test/resources/codegen/vue3_admin_uniapp_one/vue/detail/index
+++ b/yudao-module-infra/yudao-module-infra-server/src/test/resources/codegen/vue3_admin_uniapp_one/vue/detail/index
@@ -51,6 +51,7 @@
 import type { Student } from '@/api/infra/demo'
 import { onUnload } from '@dcloudio/uni-app'
 import { onMounted, ref } from 'vue'
+import { useDialog } from '@wot-ui/ui/components/wd-dialog'
 import { useToast } from '@wot-ui/ui/components/wd-toast'
 import { deleteStudent, getStudent } from '@/api/infra/demo'
 import { useAccess } from '@/hooks/useAccess'
@@ -59,7 +60,7 @@ import { DICT_TYPE } from '@/utils/constants'
 import { formatDateTime } from '@/utils/date'
 
 const props = defineProps<{
-  id?: number | any
+  id?: number
 }>()
 
 definePage({
@@ -70,6 +71,7 @@ definePage({
 })
 
 const { hasAccessByCodes } = useAccess()
+const dialog = useDialog()
 const toast = useToast()
 const formData = ref<Student>() // 详情数据
 const deleting = ref(false) // 删除状态
@@ -100,28 +102,27 @@ function handleEdit() {
 }
 
 /** 删除学生 */
-function handleDelete() {
+async function handleDelete() {
   if (!props.id) {
     return
   }
-  uni.showModal({
-    title: '提示',
-    content: '确定要删除该学生吗？',
-    success: async (res) => {
-      if (!res.confirm) {
-        return
-      }
-      deleting.value = true
-      try {
-        await deleteStudent(props.id)
-        toast.success('删除成功')
-        uni.$emit('infra:demo:reload')
-        delay(handleBack)
-      } finally {
-        deleting.value = false
-      }
-    },
-  })
+  try {
+    await dialog.confirm({
+      title: '提示',
+      msg: '确定要删除该学生吗？',
+    })
+  } catch {
+    return
+  }
+  deleting.value = true
+  try {
+    await deleteStudent(props.id)
+    toast.success('删除成功')
+    uni.$emit('infra:demo:reload')
+    delay(handleBack)
+  } finally {
+    deleting.value = false
+  }
 }
 
 /** 初始化 */

--- a/yudao-module-infra/yudao-module-infra-server/src/test/resources/codegen/vue3_admin_uniapp_one/vue/form/index
+++ b/yudao-module-infra/yudao-module-infra-server/src/test/resources/codegen/vue3_admin_uniapp_one/vue/form/index
@@ -54,6 +54,7 @@
               <wd-radio
                 v-for="dict in getBoolDictOptions(DICT_TYPE.INFRA_BOOLEAN_STRING)"
                 :key="dict.value"
+                :name="dict.value"
                 :value="dict.value"
               >
                 {{ dict.label }}
@@ -104,7 +105,7 @@ import { formatDateTime } from '@/utils/date'
 import { createFormSchema } from '@/utils/wot'
 
 const props = defineProps<{
-  id?: number | any
+  id?: number
 }>()
 
 definePage({
@@ -121,7 +122,7 @@ const formData = ref<Student>({
   id: undefined,
   name: '',
   description: '',
-  birthday: undefined,
+  birthday: Date.now(),
   sex: 0,
   enabled: false,
   avatar: '',

--- a/yudao-module-infra/yudao-module-infra-server/src/test/resources/codegen/vue3_admin_uniapp_one/vue/search-form
+++ b/yudao-module-infra/yudao-module-infra-server/src/test/resources/codegen/vue3_admin_uniapp_one/vue/search-form
@@ -32,12 +32,13 @@
           性别
         </view>
         <wd-radio-group v-model="formData.sex" type="button">
-          <wd-radio :value="-1">
+          <wd-radio :name="-1" :value="-1">
             全部
           </wd-radio>
           <wd-radio
             v-for="dict in getIntDictOptions(DICT_TYPE.SYSTEM_USER_SEX)"
             :key="dict.value"
+            :name="dict.value"
             :value="dict.value"
           >
             {{ dict.label }}
@@ -49,12 +50,13 @@
           是否有效
         </view>
         <wd-radio-group v-model="formData.enabled" type="button">
-          <wd-radio :value="-1">
+          <wd-radio :name="-1" :value="-1">
             全部
           </wd-radio>
           <wd-radio
             v-for="dict in getBoolDictOptions(DICT_TYPE.INFRA_BOOLEAN_STRING)"
             :key="dict.value"
+            :name="dict.value"
             :value="dict.value"
           >
             {{ dict.label }}
@@ -119,12 +121,13 @@ const placeholder = computed(() => {
 /** 搜索按钮操作 */
 function handleSearch() {
   visible.value = false
-  emit('search', {
+  const data: Record<string, any> = {
     ...formData,
     sex: formData.sex === -1 ? undefined : formData.sex,
     enabled: formData.enabled === -1 ? undefined : formData.enabled,
     createTime: formatDateRange(formData.createTime),
-  })
+  }
+  emit('search', data)
 }
 
 /** 重置按钮操作 */


### PR DESCRIPTION
## Problem

`CodegenEngineUniappTest.testExecute_one` fails because the uniapp velocity templates were updated in a previous commit, but the corresponding golden test files were not regenerated.

## Root Cause

The velocity templates under `codegen/vue3_admin_uniapp/components/` were modified (e.g., `search-form.vue.vm`), adding:
- `:name` attribute to `wd-radio` components
- Refactored `handleSearch` to use `const data` variable before emit
- Switched detail page delete confirmation from `uni.showModal` to `useDialog().confirm()`
- Changed `id` type from `number | any` to `number`

However, the golden snapshot files under `test/resources/codegen/vue3_admin_uniapp_one/` were not updated to reflect these template changes.

## Fix

Regenerated all 3 affected golden files using the project's built-in mechanism:

```bash
mvn test -pl yudao-module-infra/yudao-module-infra-server \
  -Dtest=CodegenEngineUniappTest -Dcodegen.regenerate=true