### PR TITLE
fix(pay): correct YAML indentation for Redis config in test

### DIFF
--- a/yudao-module-pay/yudao-module-pay-server/src/test/resources/application-unit-test.yaml
+++ b/yudao-module-pay/yudao-module-pay-server/src/test/resources/application-unit-test.yaml
@@ -21,11 +21,11 @@ spring:
       schema-locations: classpath:/sql/create_tables.sql
 
   # Redis 配置。Redisson 默认的配置足够使用，一般不需要进行调优
-    data:
-      redis:
-        host: 127.0.0.1 # 地址
-        port: 16379 # 端口（单元测试，使用 16379 端口）
-        database: 0 # 数据库索引
+  data:
+    redis:
+      host: 127.0.0.1 # 地址
+      port: 16379 # 端口（单元测试，使用 16379 端口）
+      database: 0 # 数据库索引
 
 mybatis:
   lazy-initialization: true # 单元测试，设置 MyBatis Mapper 延迟加载，加速每个单元测试


### PR DESCRIPTION
## Problem

Unit tests in `yudao-module-pay-server` fail with `NOAUTH Authentication required` when a password-protected Redis is running on the default port (6379).

Tests affected:
- `PayOrderServiceTest` (2 tests)
- `PayRefundServiceTest` (2 tests)

All fail at `PayNoRedisDAO.generate()` which calls `redisTemplate.opsForValue().increment()`.

## Root Cause

In `application-unit-test.yaml`, the `data` key under the Redis config section is indented 4 spaces (placing it under `sql:`) instead of 2 spaces (placing it under `spring:`):

```yaml
# Before (broken) — data is under sql, becomes spring.sql.data.redis
spring:
  sql:
    init:
      schema-locations: classpath:/sql/create_tables.sql
  # Redis config
    data:          # ← 4 spaces, nested under sql
      redis:
        host: 127.0.0.1
        port: 16379
```

Because the Redis config resolves to `spring.sql.data.redis` (which Spring Boot doesn't recognize), the configuration is silently ignored. Tests fall back to the default `localhost:6379`, which fails with `NOAUTH` if that Redis requires authentication.

## Fix

Reduce `data` indentation from 4 spaces to 2 spaces so it sits at the same level as `sql` under `spring`